### PR TITLE
fix(server): pass host and port configuration to mcp.run

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -6,7 +6,6 @@
   "packages": {
     ".": {
       "package-name": "frigate-mcp",
-      "release-as": "0.0.1",
       "exclude-paths": [".github/"]
     }
   }

--- a/.github/workflows/release-containers.yaml
+++ b/.github/workflows/release-containers.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - "main"
     paths:
+      - "src/**"
       - "containers/**"
 
 # need for release-please action
@@ -25,7 +26,6 @@ jobs:
     runs-on: ubuntu-latest 
     outputs:
       paths_released: ${{ steps.release-please.outputs.paths_released }}
-      releases_created: ${{ steps.release-please.outputs.releases_created }}
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
@@ -46,13 +46,17 @@ jobs:
           config-file: .github/release-please-config.json
           manifest-file: .github/.release-please-manifest.json
       
+      - name: Debug outputs
+        run: |
+          echo "paths_released: ${{ steps.release-please.outputs.paths_released }}"
+      
 
   # Run the following section to push docker image if a release is created
   release-docker-image:
     name: Release docker image
     runs-on: ubuntu-latest
     needs: release-please
-    if: ${{ needs.release-please.outputs.releases_created }}
+    if: ${{ needs.release-please.outputs.paths_released != '[]' }}
     strategy:
       fail-fast: false 
       matrix:

--- a/src/frigate_mcp/server.py
+++ b/src/frigate_mcp/server.py
@@ -360,7 +360,11 @@ def serve_sse():
     print()
     
     # Run with SSE transport
-    mcp.run(transport="sse")
+    mcp.run(
+        transport="sse",
+        host=config.server_host,
+        port=config.server_port,
+    )
 
 
 def serve_http():
@@ -377,13 +381,12 @@ def serve_http():
     print(f"🔗 Frigate instance: {config.base_url}")
     print()
     
-    # Set environment variables for FastMCP
-    import os
-    os.environ["MCP_HOST"] = config.server_host
-    os.environ["MCP_PORT"] = str(config.server_port)
-    
     # Run with SSE transport (FastMCP's HTTP mode)
-    mcp.run(transport="sse")
+    mcp.run(
+        transport="sse",
+        host=config.server_host,
+        port=config.server_port,
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Update mcp.run to use explicit host and port parameters from configuration. Modify release workflows to trigger on released paths and adjust release-please configuration.

**Description**

